### PR TITLE
Add excludedirs option to avoid reporting some paths

### DIFF
--- a/doxy-coverage.py
+++ b/doxy-coverage.py
@@ -117,7 +117,7 @@ def parse(path):
 	return files
 
 
-def report (files):
+def report (files, exclude_dirs):
 	def get_coverage (f):
 		defs = files[f]
 		if not defs:
@@ -138,6 +138,14 @@ def report (files):
 	total_no  = 0
 
 	for f in files_sorted:
+		skip = False
+		for exclude_dir in exclude_dirs:
+			if exclude_dir in f:
+				skip = True
+				break
+		if skip:
+			continue
+
 		defs = files[f]
 		if not defs:
 			continue
@@ -170,6 +178,8 @@ def main():
 	parser.add_argument ("dir",         action="store",      help="Path to Doxygen's XML doc directory")
 	parser.add_argument ("--noerror",   action="store_true", help="Do not return error code after execution")
 	parser.add_argument ("--threshold", action="store",      help="Min acceptable coverage percentage (Default: %s)"%(ACCEPTABLE_COVERAGE), default=ACCEPTABLE_COVERAGE, type=int)
+	parser.add_argument("--excludedirs", nargs='+', help="List of directories to be excluded from coverage analysis", type=str, default=[])
+
 
 	global ns
 	ns = parser.parse_args()
@@ -180,7 +190,7 @@ def main():
 	files = parse (ns.dir)
 
 	# Print report
-	err = report (files)
+	err = report (files, ns.excludedirs)
 	if ns.noerror:
 		return
 


### PR DESCRIPTION
Hi @alobbs ,

ir order to use doxy-coverage in semaphoreci, the CI system used by https://github.com/solettaproject/soletta , I had to add an extra option. In the case, I'm excluding the samples directory, and checking if 100% of our API is documented. So we are able to avoid new API is added without documentation.

It may be useful for others. 

Please take a look on that when you have some time.

Thanks in advance
